### PR TITLE
implement-transient-state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+ecs_auto_scale.zip

--- a/src/ecs_auto_scale.py
+++ b/src/ecs_auto_scale.py
@@ -51,7 +51,11 @@ def lambda_handler(event, context):
 
     for service in services:
         if datetime.datetime.now(datetime.timezone.utc) - service['createdAt'] > datetime.timedelta(minutes=1):
-            if service['runningCount'] + service['pendingCount'] < service['desiredCount']:
+            if service['runningCount'] >= 1 and service['pendingCount'] >= 1:
+                transient_state_desired_count = service['runningCount'] + service['pendingCount'] + service['desiredCount']
+            else:
+                transient_state_desired_count = service['desiredCount']
+            if service['runningCount'] + service['pendingCount'] < transient_state_desired_count:
                 autoscaling.set_desired_capacity(AutoScalingGroupName=asg_name, DesiredCapacity=asg['DesiredCapacity'] + 1)
                 message = "Updating asg %s desired capacity to %d" % (asg_name, asg['DesiredCapacity'] + 1)
                 print(message)


### PR DESCRIPTION
The current logic wont work when we deploying/updating a new task definition to
existing service.

* The service_desired count is still 1 which is the initial count set in ansible.
* there are pending task for new task and
* old task is still running until new task is spawned and completed thus
* `service['runningCount'] + service['pendingCount']` is always greater than `the service_desired count`
* Thus this script does nothing but it should spawn new ec2 because there are pending.

This is because the deployment config says 50% of desired count round up, and we only have desired count = 1.

The old logic still supported in here out side of the transient deployment state.

CPU bound / load increase case

* High cpu usages cz load increase =>
* ASG spawn new ec2
* Service Autoscale update and bump up service desired count =>
* New task allocated into the new ec2 resources.

Memory usage increase case.

* We launch new services and by the time memory usage increasing
* We scale out and we could not spawwn task thus task in pending
* This lambda will look at the current desired count (already bumped up) and compare with running + pending
* It would scale out new ec2